### PR TITLE
fix: Bump gunicorn to 22.0.0 to resolve 2 CVEs

### DIFF
--- a/examples/python-app/requirements.txt
+++ b/examples/python-app/requirements.txt
@@ -1,3 +1,3 @@
 Flask==3.0.0
-gunicorn==21.2.0
+gunicorn==22.0.0
 python-dotenv==1.0.0


### PR DESCRIPTION
## Summary
- Bump `gunicorn` from `21.2.0` to `22.0.0` to resolve 2 high-severity CVEs

## CVE Details
| Package | Severity | CVE | Fixed Version |
|---------|----------|-----|---------------|
| gunicorn | **High** | CVE-2024-6827 | 22.0.0 |
| gunicorn | **High** | CVE-2024-1135 | 22.0.0 |

## Test plan
- [ ] Verify `pip install -r requirements.txt` succeeds
- [ ] Confirm Flask example app starts with gunicorn 22.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped gunicorn to 22.0.0 in the example Python app to patch two high-severity CVEs (CVE-2024-6827, CVE-2024-1135). No other changes.

- **Dependencies**
  - gunicorn: 21.2.0 → 22.0.0

<sup>Written for commit 3f0d0383c79274eab964ad8dc4faf96d5c12f796. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

